### PR TITLE
feat: Sort ads by sequence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3951,7 +3951,7 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
+                "@ygoto3/omap-vmap-parser": "^0.0.1"
             },
             "devDependencies": {
                 "typescript": "^5.3.3"
@@ -3982,7 +3982,7 @@
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0"
+                "@ygoto3/omap-core": "^0.0.1"
             },
             "devDependencies": {
                 "dashjs": "^4.7.2",
@@ -4026,8 +4026,8 @@
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-dashjs-binder": "^0.0.1"
+                "@ygoto3/omap-core": "^0.0.1",
+                "@ygoto3/omap-dashjs-binder": "^0.0.2"
             },
             "devDependencies": {
                 "dashjs": "^4.7.2",
@@ -4079,8 +4079,8 @@
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-dashjs-binder": "^0.0.1"
+                "@ygoto3/omap-core": "^0.0.1",
+                "@ygoto3/omap-dashjs-binder": "^0.0.2"
             },
             "devDependencies": {
                 "dashjs": "^4.7.2",
@@ -4089,30 +4089,6 @@
                 "webpack": "^5.65.0",
                 "webpack-cli": "^4.9.1",
                 "webpack-merge": "^5.10.0"
-            }
-        },
-        "packages/dashjs-ui-binder/node_modules/@ygoto3/omap-core": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-core/-/omap-core-0.0.0.tgz",
-            "integrity": "sha512-G/KyTt0ed7Wskyy1IWiQveScL3cBtWlxaiGnbniR/Lr8C/NY1IvSwe5Z06VnoG3yi1n5g+BQ7q33Ww8TAnQjbw==",
-            "dependencies": {
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
-            }
-        },
-        "packages/dashjs-ui-binder/node_modules/@ygoto3/omap-dashjs-binder": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-dashjs-binder/-/omap-dashjs-binder-0.0.1.tgz",
-            "integrity": "sha512-rCprqlkRnYMHhROf9WEtkV2RNG7ktL+ucFgVpS6LAZ1Ud6u18NBMQjZwHu81g3No2Z2nEomTlvMPD0Ul39L6Ow==",
-            "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0"
-            }
-        },
-        "packages/dashjs-ui-binder/node_modules/@ygoto3/omap-vmap-parser": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-vmap-parser/-/omap-vmap-parser-0.0.0.tgz",
-            "integrity": "sha512-/snXIfUUrp4bDfeFQUey3GZwOWiPFTT2SFxzNmEpDd5vEhFeOueWsFsUVEWIEVPi7SHF6ZEXhW5nzVaJBejIkg==",
-            "dependencies": {
-                "xml-js": "^1.6.11"
             }
         },
         "packages/dashjs-ui-binder/node_modules/typescript": {
@@ -4131,11 +4107,11 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-dashjs-binder": "^0.0.0",
-                "@ygoto3/omap-dashjs-sd-binder": "^0.0.0",
-                "@ygoto3/omap-dashjs-ui-binder": "^0.0.0",
-                "@ygoto3/omap-iab-client": "^0.0.0",
+                "@ygoto3/omap-core": "^0.0.1",
+                "@ygoto3/omap-dashjs-binder": "^0.0.2",
+                "@ygoto3/omap-dashjs-sd-binder": "^0.0.2",
+                "@ygoto3/omap-dashjs-ui-binder": "^0.0.2",
+                "@ygoto3/omap-iab-client": "^0.0.1",
                 "dashjs": "^4.7.2"
             },
             "devDependencies": {
@@ -4186,50 +4162,6 @@
                 "webpack-dev-server": {
                     "optional": true
                 }
-            }
-        },
-        "packages/demo/node_modules/@ygoto3/omap-core": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-core/-/omap-core-0.0.0.tgz",
-            "integrity": "sha512-G/KyTt0ed7Wskyy1IWiQveScL3cBtWlxaiGnbniR/Lr8C/NY1IvSwe5Z06VnoG3yi1n5g+BQ7q33Ww8TAnQjbw==",
-            "dependencies": {
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
-            }
-        },
-        "packages/demo/node_modules/@ygoto3/omap-dashjs-binder": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-dashjs-binder/-/omap-dashjs-binder-0.0.0.tgz",
-            "integrity": "sha512-X5K7oKNW24Gr2/Dovgd8ETclGjyOKqvttbRbXbIiWnrLXxQH3P4jTyg5evxAldnoqUCybeU5PsKKQZEbN4riyw==",
-            "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0"
-            }
-        },
-        "packages/demo/node_modules/@ygoto3/omap-dashjs-sd-binder": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-dashjs-sd-binder/-/omap-dashjs-sd-binder-0.0.0.tgz",
-            "integrity": "sha512-ppHztwgOfo0iruuwOGaTdVdZE86fpIenuFUmIf2SHbCuJHp7d6KEsDMJ3HW6d2QzAsNbc89e5j/RkhPOYRxLvw==",
-            "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-dashjs-binder": "^0.0.0"
-            }
-        },
-        "packages/demo/node_modules/@ygoto3/omap-dashjs-ui-binder": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-dashjs-ui-binder/-/omap-dashjs-ui-binder-0.0.0.tgz",
-            "integrity": "sha512-ug4t5DeejMFuf08k0kQ7czbREqLtBp98rDBBsOpNIvQxnO11Re3VOaYXOKs3LMJWB3frIqX7f5WmkTLtcYgiZQ==",
-            "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-dashjs-binder": "^0.0.0"
-            }
-        },
-        "packages/demo/node_modules/@ygoto3/omap-iab-client": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-iab-client/-/omap-iab-client-0.0.0.tgz",
-            "integrity": "sha512-42dfqdL0Rq2I6AwbSUT5mdtRaa7/MabTwGMJnmrIkcP06pdnuqIZmoq7kQcQUaqN02aJWwZFMR8MGPiP7YrRaw==",
-            "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-vast-parser": "^0.0.0",
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
             }
         },
         "packages/demo/node_modules/@ygoto3/omap-vast-parser": {
@@ -4324,9 +4256,9 @@
             "version": "0.0.1",
             "license": "MIT",
             "dependencies": {
-                "@ygoto3/omap-core": "^0.0.0",
-                "@ygoto3/omap-vast-parser": "^0.0.0",
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
+                "@ygoto3/omap-core": "^0.0.1",
+                "@ygoto3/omap-vast-parser": "^0.0.1",
+                "@ygoto3/omap-vmap-parser": "^0.0.1"
             },
             "devDependencies": {
                 "ts-loader": "^9.5.1",
@@ -4336,30 +4268,6 @@
                 "webpack": "^5.65.0",
                 "webpack-cli": "^4.9.1",
                 "webpack-merge": "^5.10.0"
-            }
-        },
-        "packages/iab-client/node_modules/@ygoto3/omap-core": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-core/-/omap-core-0.0.0.tgz",
-            "integrity": "sha512-G/KyTt0ed7Wskyy1IWiQveScL3cBtWlxaiGnbniR/Lr8C/NY1IvSwe5Z06VnoG3yi1n5g+BQ7q33Ww8TAnQjbw==",
-            "dependencies": {
-                "@ygoto3/omap-vmap-parser": "^0.0.0"
-            }
-        },
-        "packages/iab-client/node_modules/@ygoto3/omap-vast-parser": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-vast-parser/-/omap-vast-parser-0.0.0.tgz",
-            "integrity": "sha512-mYVD88T53t/9HEtx/Ef+E90h9OzGJRIslh5mt6xL5eALCV6lkllL5HkM2Qn6aor9z50Wc8SFqN5fw2TbPWkWkg==",
-            "dependencies": {
-                "xml-js": "^1.6.11"
-            }
-        },
-        "packages/iab-client/node_modules/@ygoto3/omap-vmap-parser": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/@ygoto3/omap-vmap-parser/-/omap-vmap-parser-0.0.0.tgz",
-            "integrity": "sha512-/snXIfUUrp4bDfeFQUey3GZwOWiPFTT2SFxzNmEpDd5vEhFeOueWsFsUVEWIEVPi7SHF6ZEXhW5nzVaJBejIkg==",
-            "dependencies": {
-                "xml-js": "^1.6.11"
             }
         },
         "packages/iab-client/node_modules/typescript": {

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -13,11 +13,11 @@
   },
   "dependencies": {
     "dashjs": "^4.7.2",
-    "@ygoto3/omap-core": "^0.0.0",
-    "@ygoto3/omap-iab-client": "^0.0.0",
-    "@ygoto3/omap-dashjs-binder": "^0.0.0",
-    "@ygoto3/omap-dashjs-sd-binder": "^0.0.0",
-    "@ygoto3/omap-dashjs-ui-binder": "^0.0.0"
+    "@ygoto3/omap-core": "^0.0.1",
+    "@ygoto3/omap-iab-client": "^0.0.1",
+    "@ygoto3/omap-dashjs-binder": "^0.0.2",
+    "@ygoto3/omap-dashjs-sd-binder": "^0.0.2",
+    "@ygoto3/omap-dashjs-ui-binder": "^0.0.2"
   },
   "devDependencies": {
     "ts-loader": "^9.2.6",

--- a/packages/iab-client/tests/index.test.ts
+++ b/packages/iab-client/tests/index.test.ts
@@ -49,6 +49,22 @@ test('adTagUrl is vmap', async () => {
     const midroll_1_ad_1_creative_1_tracking_midpoint = createPromise();
     const midroll_1_ad_1_creative_1_tracking_thirdQuartile = createPromise();
     const midroll_1_ad_1_creative_1_tracking_complete = createPromise();
+
+    const midroll_2 = createPromise();
+
+    const midroll_2_ad_1_impression_1 = createPromise();
+    const midroll_2_ad_1_creative_1_tracking_start = createPromise();
+    const midroll_2_ad_1_creative_1_tracking_firstQuartile = createPromise();
+    const midroll_2_ad_1_creative_1_tracking_midpoint = createPromise();
+    const midroll_2_ad_1_creative_1_tracking_thirdQuartile = createPromise();
+    const midroll_2_ad_1_creative_1_tracking_complete = createPromise();
+
+    const midroll_2_ad_2_impression_1 = createPromise();
+    const midroll_2_ad_2_creative_1_tracking_start = createPromise();
+    const midroll_2_ad_2_creative_1_tracking_firstQuartile = createPromise();
+    const midroll_2_ad_2_creative_1_tracking_midpoint = createPromise();
+    const midroll_2_ad_2_creative_1_tracking_thirdQuartile = createPromise();
+    const midroll_2_ad_2_creative_1_tracking_complete = createPromise();
     
     adClient.on(OmapClientEvent.CONTENT_PAUSE_REQUESTED, () => {
         content_pause_requested_count++;
@@ -81,17 +97,17 @@ test('adTagUrl is vmap', async () => {
                         </vmap:AdBreak>
                         <vmap:AdBreak timeOffset="00:00:15.000" breakType="linear" breakId="midroll-1">
                             <vmap:AdSource id="midroll-1-ad-1" allowMultipleAds="false" followRedirects="true">
-                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-1-ad-1]]></vmap:AdTagURI>
+                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-1]]></vmap:AdTagURI>
                             </vmap:AdSource>
                         </vmap:AdBreak>
                         <vmap:AdBreak timeOffset="00:00:30.000" breakType="linear" breakId="midroll-2">
-                            <vmap:AdSource id="midroll-1-ad-2" allowMultipleAds="false" followRedirects="true">
-                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-1-ad-2]]></vmap:AdTagURI>
+                            <vmap:AdSource id="midroll-2-ad-1" allowMultipleAds="false" followRedirects="true">
+                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-2]]></vmap:AdTagURI>
                             </vmap:AdSource>
                         </vmap:AdBreak>
                         <vmap:AdBreak timeOffset="00:00:45.000" breakType="linear" breakId="midroll-3">
-                            <vmap:AdSource id="midroll-1-ad-3" allowMultipleAds="false" followRedirects="true">
-                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-1-ad-3]]></vmap:AdTagURI>
+                            <vmap:AdSource id="midroll-3-ad-1" allowMultipleAds="false" followRedirects="true">
+                                <vmap:AdTagURI templateType="vast3"><![CDATA[https://example.com/vast/midroll-3]]></vmap:AdTagURI>
                             </vmap:AdSource>
                         </vmap:AdBreak>
                         <vmap:AdBreak timeOffset="end" breakType="linear" breakId="postroll">
@@ -190,7 +206,7 @@ test('adTagUrl is vmap', async () => {
                         </Ad>
                     </VAST>
                 `);
-            case 'https://example.com/vast/midroll-1-ad-1':
+            case 'https://example.com/vast/midroll-1':
                 midroll_1.resolve();
                 return Promise.resolve(`
                     <?xml version="1.0" encoding="UTF-8"?>
@@ -199,23 +215,106 @@ test('adTagUrl is vmap', async () => {
                             <InLine>
                                 <AdSystem>SSP</AdSystem>
                                 <AdTitle>DSP></AdTitle>
-                                <Impression><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/impression/1]]></Impression>
+                                <Impression><![CDATA[https://example.com/vast/midroll-1/ad/1/impression/1]]></Impression>
                                 <Impression></Impression>
                                 <Description></Description>
                                 <Advertiser>example.com</Advertiser>
                                 <Survey type=""></Survey>
-                                <Error><![CDATA[https://example.com/vast/midroll-1-ad-1/ad/1/error/1]]></Error>
-                                <Error><![CDATA[https://example.com/vast/midroll-1-ad-1/ad/1/error/2]]></Error>
+                                <Error><![CDATA[https://example.com/vast/midroll-1/ad/1/error/1]]></Error>
+                                <Error><![CDATA[https://example.com/vast/midroll-1/ad/1/error/2]]></Error>
                                 <Creatives>
                                     <Creative id="1">
                                     <Linear>
                                         <Duration>00:00:10</Duration>
                                         <TrackingEvents>
-                                            <Tracking event="start"><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/start]]></Tracking>
-                                            <Tracking event="firstQuartile"><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/firstQuartile]]></Tracking>
-                                            <Tracking event="midpoint"><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/midpoint]]></Tracking>
-                                            <Tracking event="thirdQuartile"><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/thirdQuartile]]></Tracking>
-                                            <Tracking event="complete"><![CDATA[https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/complete]]></Tracking>
+                                            <Tracking event="start"><![CDATA[https://example.com/vast/midroll-1/ad/1/creative/1/tracking/start]]></Tracking>
+                                            <Tracking event="firstQuartile"><![CDATA[https://example.com/vast/midroll-1/ad/1/creative/1/tracking/firstQuartile]]></Tracking>
+                                            <Tracking event="midpoint"><![CDATA[https://example.com/vast/midroll-1/ad/1/creative/1/tracking/midpoint]]></Tracking>
+                                            <Tracking event="thirdQuartile"><![CDATA[https://example.com/vast/midroll-1/ad/1/creative/1/tracking/thirdQuartile]]></Tracking>
+                                            <Tracking event="complete"><![CDATA[https://example.com/vast/midroll-1/ad/1/creative/1/tracking/complete]]></Tracking>
+                                        </TrackingEvents>
+                                        <MediaFiles>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="4000" width="1920" height="1080"><![CDATA[https://example.com/media/vod-4000k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720"><![CDATA[https://example.com/media/vod-2000k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="1200" width="854" height="480"><![CDATA[https://example.com/media/vod-1200k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="800" width="640" height="360"><![CDATA[https://example.com/media/vod-800k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="240" width="426" height="240"><![CDATA[https://example.com/media/vod-240k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="120" width="320" height="180"><![CDATA[https://example.com/media/vod-120k-5.mp4]]></MediaFile>
+                                        </MediaFiles>
+                                    </Linear>
+                                    <CreativeExtensions>
+                                        <CreativeExtension type="type-1"><ID>4237</ID></CreativeExtension>
+                                    </CreativeExtensions>
+                                    </Creative>
+                                </Creatives>
+                            </InLine>
+                        </Ad>
+                    </VAST>
+                `);
+            case 'https://example.com/vast/midroll-2':
+                midroll_2.resolve();
+                return Promise.resolve(`
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <VAST xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vast.xsd" version="3.0">
+                        <Ad>
+                            <InLine>
+                                <AdSystem>SSP</AdSystem>
+                                <AdTitle>DSP></AdTitle>
+                                <Impression><![CDATA[https://example.com/vast/midroll-2/ad/1/impression/1]]></Impression>
+                                <Impression></Impression>
+                                <Description></Description>
+                                <Advertiser>example.com</Advertiser>
+                                <Survey type=""></Survey>
+                                <Error><![CDATA[https://example.com/vast/midroll-2/ad/2/error/1]]></Error>
+                                <Error><![CDATA[https://example.com/vast/midroll-2/ad/2/error/2]]></Error>
+                                <Creatives>
+                                    <Creative id="1">
+                                    <Linear>
+                                        <Duration>00:00:10</Duration>
+                                        <TrackingEvents>
+                                            <Tracking event="start"><![CDATA[https://example.com/vast/midroll-2/ad/1/creative/1/tracking/start]]></Tracking>
+                                            <Tracking event="firstQuartile"><![CDATA[https://example.com/vast/midroll-2/ad/1/creative/1/tracking/firstQuartile]]></Tracking>
+                                            <Tracking event="midpoint"><![CDATA[https://example.com/vast/midroll-2/ad/1/creative/1/tracking/midpoint]]></Tracking>
+                                            <Tracking event="thirdQuartile"><![CDATA[https://example.com/vast/midroll-2/ad/1/creative/1/tracking/thirdQuartile]]></Tracking>
+                                            <Tracking event="complete"><![CDATA[https://example.com/vast/midroll-2/ad/1/creative/1/tracking/complete]]></Tracking>
+                                        </TrackingEvents>
+                                        <MediaFiles>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="4000" width="1920" height="1080"><![CDATA[https://example.com/media/vod-4000k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720"><![CDATA[https://example.com/media/vod-2000k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="1200" width="854" height="480"><![CDATA[https://example.com/media/vod-1200k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="800" width="640" height="360"><![CDATA[https://example.com/media/vod-800k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="240" width="426" height="240"><![CDATA[https://example.com/media/vod-240k-5.mp4]]></MediaFile>
+                                            <MediaFile delivery="progressive" type="video/mp4" bitrate="120" width="320" height="180"><![CDATA[https://example.com/media/vod-120k-5.mp4]]></MediaFile>
+                                        </MediaFiles>
+                                    </Linear>
+                                    <CreativeExtensions>
+                                        <CreativeExtension type="type-1"><ID>4237</ID></CreativeExtension>
+                                    </CreativeExtensions>
+                                    </Creative>
+                                </Creatives>
+                            </InLine>
+                        </Ad>
+                        <Ad sequence="2">
+                            <InLine>
+                                <AdSystem>SSP</AdSystem>
+                                <AdTitle>DSP></AdTitle>
+                                <Impression><![CDATA[https://example.com/vast/midroll-2/ad/2/impression/1]]></Impression>
+                                <Impression></Impression>
+                                <Description></Description>
+                                <Advertiser>example.com</Advertiser>
+                                <Survey type=""></Survey>
+                                <Error><![CDATA[https://example.com/vast/midroll-2/ad/2/error/1]]></Error>
+                                <Error><![CDATA[https://example.com/vast/midroll-2/ad/2/error/2]]></Error>
+                                <Creatives>
+                                    <Creative id="1">
+                                    <Linear>
+                                        <Duration>00:00:10</Duration>
+                                        <TrackingEvents>
+                                            <Tracking event="start"><![CDATA[https://example.com/vast/midroll-2/ad/2/creative/1/tracking/start]]></Tracking>
+                                            <Tracking event="firstQuartile"><![CDATA[https://example.com/vast/midroll-2/ad/2/creative/1/tracking/firstQuartile]]></Tracking>
+                                            <Tracking event="midpoint"><![CDATA[https://example.com/vast/midroll-2/ad/2/creative/1/tracking/midpoint]]></Tracking>
+                                            <Tracking event="thirdQuartile"><![CDATA[https://example.com/vast/midroll-2/ad/2/creative/1/tracking/thirdQuartile]]></Tracking>
+                                            <Tracking event="complete"><![CDATA[https://example.com/vast/midroll-2/ad/2/creative/1/tracking/complete]]></Tracking>
                                         </TrackingEvents>
                                         <MediaFiles>
                                             <MediaFile delivery="progressive" type="video/mp4" bitrate="4000" width="1920" height="1080"><![CDATA[https://example.com/media/vod-4000k-5.mp4]]></MediaFile>
@@ -283,23 +382,59 @@ test('adTagUrl is vmap', async () => {
             case 'https://example.com/vast/ad/2/creative/1/tracking/complete':
                 ad_2_creative_1_tracking_complete.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/impression/1':
+            case 'https://example.com/vast/midroll-1/ad/1/impression/1':
                 midroll_1_ad_1_impression_1.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/start':
+            case 'https://example.com/vast/midroll-1/ad/1/creative/1/tracking/start':
                 midroll_1_ad_1_creative_1_tracking_start.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/firstQuartile':
+            case 'https://example.com/vast/midroll-1/ad/1/creative/1/tracking/firstQuartile':
                 midroll_1_ad_1_creative_1_tracking_firstQuartile.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/midpoint':
+            case 'https://example.com/vast/midroll-1/ad/1/creative/1/tracking/midpoint':
                 midroll_1_ad_1_creative_1_tracking_midpoint.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/thirdQuartile':
+            case 'https://example.com/vast/midroll-1/ad/1/creative/1/tracking/thirdQuartile':
                 midroll_1_ad_1_creative_1_tracking_thirdQuartile.resolve();
                 return Promise.resolve('');
-            case 'https://example.com/vmap/midroll-1/vast/ad/1/creative/1/tracking/complete':
+            case 'https://example.com/vast/midroll-1/ad/1/creative/1/tracking/complete':
                 midroll_1_ad_1_creative_1_tracking_complete.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/impression/1':
+                midroll_2_ad_1_impression_1.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/creative/1/tracking/start':
+                midroll_2_ad_1_creative_1_tracking_start.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/creative/1/tracking/firstQuartile':
+                midroll_2_ad_1_creative_1_tracking_firstQuartile.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/creative/1/tracking/midpoint':
+                midroll_2_ad_1_creative_1_tracking_midpoint.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/creative/1/tracking/thirdQuartile':
+                midroll_2_ad_1_creative_1_tracking_thirdQuartile.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/1/creative/1/tracking/complete':
+                midroll_2_ad_1_creative_1_tracking_complete.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/impression/1':
+                midroll_2_ad_2_impression_1.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/creative/1/tracking/start':
+                midroll_2_ad_2_creative_1_tracking_start.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/creative/1/tracking/firstQuartile':
+                midroll_2_ad_2_creative_1_tracking_firstQuartile.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/creative/1/tracking/midpoint':
+                midroll_2_ad_2_creative_1_tracking_midpoint.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/creative/1/tracking/thirdQuartile':
+                midroll_2_ad_2_creative_1_tracking_thirdQuartile.resolve();
+                return Promise.resolve('');
+            case 'https://example.com/vast/midroll-2/ad/2/creative/1/tracking/complete':
+                midroll_2_ad_2_creative_1_tracking_complete.resolve();
                 return Promise.resolve('');
             default:
                 return Promise.reject('Should not be called');
@@ -407,7 +542,7 @@ test('adTagUrl is vmap', async () => {
     await midroll_1_ad_1_creative_1_tracking_firstQuartile.promise;
     assert.ok(true, 'Midroll 1 Creative 1 tracking firstQuartile should be sent');
 
-    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 5.0, ad.sequence, );
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 5.0, ad.sequence);
     await midroll_1_ad_1_creative_1_tracking_midpoint.promise;
     assert.ok(true, 'Midroll 1 Creative 1 tracking midpoint should be sent');
 
@@ -424,6 +559,69 @@ test('adTagUrl is vmap', async () => {
     }
 
     assert.is(content_resume_requested_count, 1, 'Content resume should be requested');
+
+    adClient.notifyCurrentTime(30);
+    await midroll_2.promise;
+
+    // midroll 2 - 1st ad
+    ad = ad_pod!.ads[0];
+    
+    adClient.notifyAdStarted(ad);
+    await midroll_2_ad_1_impression_1.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Impression 1 should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 0.2, ad.sequence);
+    await midroll_2_ad_1_creative_1_tracking_start.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Creative 1 tracking start should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 2.5, ad.sequence);
+    await midroll_2_ad_1_creative_1_tracking_firstQuartile.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Creative 1 tracking firstQuartile should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 5.0, ad.sequence);
+    await midroll_2_ad_1_creative_1_tracking_midpoint.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Creative 1 tracking midpoint should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 7.5, ad.sequence);
+    await midroll_2_ad_1_creative_1_tracking_thirdQuartile.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Creative 1 tracking thirdQuartile should be sent');
+
+    adClient.notifyAdCreativeEnded(ad.adCreatives[0], ad.sequence);
+    await midroll_2_ad_1_creative_1_tracking_complete.promise;
+    assert.ok(true, 'Midroll 2 Ad 1 Creative 1 tracking complete should be sent');
+
+    // midroll 2 - 2nd ad
+    ad = ad_pod!.ads[1];
+    
+    adClient.notifyAdStarted(ad);
+    await midroll_2_ad_2_impression_1.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Impression 1 should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 0.2, ad.sequence);
+    await midroll_2_ad_2_creative_1_tracking_start.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Creative 1 tracking start should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 2.5, ad.sequence);
+    await midroll_2_ad_2_creative_1_tracking_firstQuartile.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Creative 1 tracking firstQuartile should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 5.0, ad.sequence);
+    await midroll_2_ad_2_creative_1_tracking_midpoint.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Creative 1 tracking midpoint should be sent');
+
+    adClient.notifyAdCreativePlaying(ad.adCreatives[0], 7.5, ad.sequence);
+    await midroll_2_ad_2_creative_1_tracking_thirdQuartile.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Creative 1 tracking thirdQuartile should be sent');
+
+    adClient.notifyAdCreativeEnded(ad.adCreatives[0], ad.sequence);
+    await midroll_2_ad_2_creative_1_tracking_complete.promise;
+    assert.ok(true, 'Midroll 2 Ad 2 Creative 1 tracking complete should be sent');
+
+    if (ad_pod!.ads.length === ad.sequence) {
+        adClient.notifyAdPodEnded();
+    }
+
+    assert.is(content_resume_requested_count, 2, 'Content resume should be requested');
 });
 
 test('sort ads by sequence', async () => {

--- a/packages/vast-parser/src/VASTParser.ts
+++ b/packages/vast-parser/src/VASTParser.ts
@@ -125,7 +125,7 @@ export default class VASTParser {
                 return new Impression(impression._cdata);
             });
             const inLine = new InLine('', '', impressions, creatives, void 0, void 0, void 0, void 0, void 0, errors, extensions);
-            const newAd = new Ad(ad._attributes.id, ad._attributes.sequence ? parseInt(ad._attributes.sequence) : void 0, inLine);
+            const newAd = new Ad(ad._attributes?.id, ad._attributes?.sequence ? parseInt(ad._attributes.sequence) : void 0, inLine);
             return newAd;
         });
         const newVast = new VAST(vastObj._attributes.version, ads);

--- a/packages/vast-parser/src/XmlVAST.ts
+++ b/packages/vast-parser/src/XmlVAST.ts
@@ -22,7 +22,7 @@ interface XmlVASTError {
 
 // 3.3 Ad
 interface XmlVASTAd {
-    _attributes: XmlVASTAdAttributes;
+    _attributes?: XmlVASTAdAttributes;
     InLine?: XmlVASTInLine;
     Wrapper?: XmlVASTWrapper;
 }

--- a/packages/vast-parser/tests/index.test.ts
+++ b/packages/vast-parser/tests/index.test.ts
@@ -6,7 +6,7 @@ import VASTParser from '../src/VASTParser';
 
 const test = suite('VASTParser');
 
-test('parse normal VMAP', () => {
+test('parse normal VAST', () => {
     let vast: string;
     let parser: VASTParser;
     let ad: Ad;
@@ -97,6 +97,46 @@ test('parse normal VMAP', () => {
                     </Creatives>
                 </InLine>
             </Ad>
+            <Ad>
+                <InLine>
+                    <AdSystem>SSP</AdSystem>
+                    <AdTitle>DSP></AdTitle>
+                    <Impression><![CDATA[https://example.com/vast/ad/3/impression/1]]></Impression>
+                    <Impression><![CDATA[https://example.com/vast/ad/3/impression/2]]></Impression>
+                    <Description></Description>
+                    <Advertiser>example.com</Advertiser>
+                    <Survey type=""></Survey>
+                    <Error><![CDATA[https://example.com/vast/ad/3/error/1]]></Error>
+                    <Error><![CDATA[https://example.com/vast/ad/3/error/2]]></Error>
+                    <Extensions>
+                    </Extensions>
+                    <Creatives>
+                        <Creative id="1">
+                        <Linear>
+                            <Duration>00:00:10</Duration>
+                            <TrackingEvents>
+                                <Tracking event="start"><![CDATA[https://example.com/vast/ad/3/creative/1/tracking/start]]></Tracking>
+                                <Tracking event="firstQuartile"><![CDATA[https://example.com/vast/ad/3/creative/1/tracking/firstQuartile]]></Tracking>
+                                <Tracking event="midpoint"><![CDATA[https://example.com/vast/ad/3/creative/1/tracking/midpoint]]></Tracking>
+                                <Tracking event="thirdQuartile"><![CDATA[https://example.com/vast/ad/3/creative/1/tracking/thirdQuartile]]></Tracking>
+                                <Tracking event="complete"><![CDATA[https://example.com/vast/ad/3/creative/1/tracking/complete]]></Tracking>
+                            </TrackingEvents>
+                            <MediaFiles>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="4000" width="1920" height="1080"><![CDATA[https://example.com/media/vod-4000k-5.mp4]]></MediaFile>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="2000" width="1280" height="720"><![CDATA[https://example.com/media/vod-2000k-5.mp4]]></MediaFile>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="1200" width="854" height="480"><![CDATA[https://example.com/media/vod-1200k-5.mp4]]></MediaFile>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="800" width="640" height="360"><![CDATA[https://example.com/media/vod-800k-5.mp4]]></MediaFile>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="240" width="426" height="240"><![CDATA[https://example.com/media/vod-240k-5.mp4]]></MediaFile>
+                                <MediaFile delivery="progressive" type="video/mp4" bitrate="120" width="320" height="180"><![CDATA[https://example.com/media/vod-120k-5.mp4]]></MediaFile>
+                            </MediaFiles>
+                        </Linear>
+                        <CreativeExtensions>
+                            <CreativeExtension type="type-1"><ID>4237</ID></CreativeExtension>
+                        </CreativeExtensions>
+                        </Creative>
+                    </Creatives>
+                </InLine>
+            </Ad>
         </VAST>
     `;
     parser = new VASTParser(vast);
@@ -106,7 +146,7 @@ test('parse normal VMAP', () => {
         return;
     }
 
-    assert.is(parsedVAST.ads.length, 2);
+    assert.is(parsedVAST.ads.length, 3);
 
     ad = parsedVAST.ads[0];
     assert.is(ad.sequence, 1);
@@ -120,9 +160,12 @@ test('parse normal VMAP', () => {
     assert.is(inLine.extensions[0].customXML, '<Root><ID><![CDATA[cdata]]></ID></Root>');
     assert.is(inLine.extensions[1].type, 'type-2', 'AD 1 extension 1 should have type "type-2"');
     assert.is(inLine.extensions[1].customXML, '<Creative><Name>4237</Name><Duration>10</Duration></Creative>', '');
+
+    ad = parsedVAST.ads[2];
+    assert.is(ad.sequence, void 0);
 });
 
-test('parse no AdBreak VMAP', () => {
+test('parse no AdBreak VAST', () => {
     let vast: string;
     let parser: VASTParser;
 


### PR DESCRIPTION
This adds a feature to sort ads to respect VAST's sequence number and to fill non-specified sequence spots with Ad elements without sequence number.