### PR TITLE
feat: Add dashjs-sd-sustainable-binder package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,10 @@
             "resolved": "packages/dashjs-sd-binder",
             "link": true
         },
+        "node_modules/@ygoto3/omap-dashjs-sd-sustainable-binder": {
+            "resolved": "packages/dashjs-sd-sustainable-binder",
+            "link": true
+        },
         "node_modules/@ygoto3/omap-dashjs-ui-binder": {
             "resolved": "packages/dashjs-ui-binder",
             "link": true
@@ -4018,6 +4022,37 @@
             "version": "5.3.3",
             "dev": true,
             "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "packages/dashjs-sd-sustainable-binder": {
+            "name": "@ygoto3/omap-dashjs-sd-sustainable-binder",
+            "version": "0.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@ygoto3/omap-core": "^0.0.1",
+                "@ygoto3/omap-dashjs-sd-binder": "^0.0.2"
+            },
+            "devDependencies": {
+                "dashjs": "^4.7.2",
+                "ts-loader": "^9.5.1",
+                "typescript": "^5.3.3",
+                "uvu": "^0.5.6",
+                "webpack": "^5.65.0",
+                "webpack-cli": "^4.9.1",
+                "webpack-merge": "^5.10.0"
+            }
+        },
+        "packages/dashjs-sd-sustainable-binder/node_modules/typescript": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+            "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/packages/core/src/AdBreak.ts
+++ b/packages/core/src/AdBreak.ts
@@ -1,0 +1,15 @@
+import type AdPod from './AdPod';
+
+export default class AdBreak {
+
+    constructor(offsetTime: number, id?: string, adPod?: AdPod) {
+        this.offsetTime = offsetTime;
+        this.id = id;
+        this.adPod = adPod;
+    }
+
+    readonly offsetTime: number;
+    readonly id?: string;
+    readonly adPod?: AdPod;
+
+}

--- a/packages/core/src/ClientEvent.ts
+++ b/packages/core/src/ClientEvent.ts
@@ -10,5 +10,6 @@ export default {
     COMPLETE: 'complete',
     AD_POD_PREPARATION_REQUESTED: 'adPodPreparationRequested',
     AD_POD_INSERTION_REQUESTED: 'adPodInsertionRequested',
+    AD_POD_INSERTION_REQUEST_FAILED: 'adPodInsertionRequestFailed',
 
 } as const;

--- a/packages/core/src/IBinder.ts
+++ b/packages/core/src/IBinder.ts
@@ -6,11 +6,14 @@ import type TBinderState from "./TBinderState";
 /** Interface for OMAP binder implementations */
 export default interface IOmapBinder {
 
-    /** The promise that is resolved when the binder is ready */
-    // readonly ready?: Promise<void>;
-
     /** The binder's state */
     readonly state: TBinderState;
+
+    /**
+     * The tricky media player handler can be provided where some interaction with the media player needs to be done in a tricky way.
+     * In that case, use the tricky media player handler's methods instead of those of the media player itself.
+     */
+    readonly trickyMediaPlayerHandler?: Object;
     
     /**
      * Will bind an OMAP client to the media player that the binder uses.

--- a/packages/core/src/IClient.ts
+++ b/packages/core/src/IClient.ts
@@ -1,5 +1,6 @@
-import type { AdBreak } from "@ygoto3/omap-vmap-parser";
+import type { AdBreak as ParserAdBreak } from "@ygoto3/omap-vmap-parser";
 import type Ad from "./Ad";
+import type AdBreak from "./AdBreak";
 import type AdCreative from "./AdCreative";
 import type AdPodInsertionRequest from "./AdPodInsertionRequest";
 import type OmapClientEvent from "./ClientEvent";
@@ -58,15 +59,20 @@ export default interface IOmapClient {
     notifyAdPlaybackError(ad: Ad): void;
 
     /**
+     * Use the method to check if the client has ad pod insertion point at the time.
+     */
+    hasAdPodInsertionAt(time: number): boolean;
+
+    /**
      * Will replace ad insertion decider.
      * @param filter the custom ad decider function
      */
     attachAdInsertionDecider(
         filter: (
             currentTime: number,
-            adBreaks: AdBreak[],
-            countAdBreakConsumption: (adBreak: AdBreak
-        ) => number) => AdBreak | undefined
+            adBreaks: ParserAdBreak[],
+            countAdBreakConsumption: (adBreak: ParserAdBreak) => number,
+        ) => ParserAdBreak | undefined
     ): void;
 
     /**
@@ -102,7 +108,7 @@ export default interface IOmapClient {
      * @param type the type of event : `OmapClientEvent.LOADED`
      * @param listener the listener function
      */
-    on(type: typeof OmapClientEvent.LOADED, listener: () => void): void;
+    on(type: typeof OmapClientEvent.LOADED, listener: (adBreaks: AdBreak[]) => void): void;
 
     /**
      * Use the on method to listen for the `LOAD_ERROR` event.
@@ -131,6 +137,13 @@ export default interface IOmapClient {
      * @param listener the listener function
      */
     on(type: typeof OmapClientEvent.AD_POD_INSERTION_REQUESTED, listener: (adPodInsertionRequest: AdPodInsertionRequest) => void): void;
+
+    /**
+     * Use the on method to listen for the `AD_POD_INSERTION_REQUEST_FAILED` event.
+     * @param type the type of event : `OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED`
+     * @param listener the listener function
+     */
+    on(type: typeof OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED, listener: () => void): void;
 
     /**
      * Use the on method to listen for the `AD_POD_PREPARATION_REQUESTED` event.
@@ -172,7 +185,7 @@ export default interface IOmapClient {
      * @param type the type of event : `OmapClientEvent.LOADED`
      * @param listener the listener function
      */
-    off(type: typeof OmapClientEvent.LOADED, listener: () => void): void;
+    off(type: typeof OmapClientEvent.LOADED, listener: (adBreaks: AdBreak[]) => void): void;
 
     /**
      * Use the off method to remove listener for the `LOAD_ERROR` event.
@@ -201,6 +214,13 @@ export default interface IOmapClient {
      * @param listener the listener function
      */
     off(type: typeof OmapClientEvent.AD_POD_INSERTION_REQUESTED, listener: (adPodInsertionRequest: AdPodInsertionRequest) => void): void;
+
+    /**
+     * Use the off method to remove listener for the `AD_POD_INSERTION_REQUEST_FAILED` event.
+     * @param type the type of event : `OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED`
+     * @param listener the listener function
+     */
+    off(type: typeof OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED, listener: () => void): void;
 
     /**
      * Use the off method to remove listener for the `AD_POD_PREPARATION_REQUESTED` event.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 import { default as Ad } from "./Ad";
+import { default as AdBreak } from "./AdBreak";
 import { default as AdCreative } from "./AdCreative";
 import { default as AdInformation } from "./AdInformation";
 import { default as AdInformationBuilder } from "./AdInformationBuilder";
@@ -19,6 +20,7 @@ import type { default as TOmapClientEvent } from "./TClientEvent";
 
 export {
     Ad,
+    AdBreak,
     AdCreative,AdInformation,
     AdInformationBuilder,
     AdMediaFile,

--- a/packages/dashjs-sd-binder/README.md
+++ b/packages/dashjs-sd-binder/README.md
@@ -19,7 +19,7 @@ $ npm install @ygoto3/omap-dashjs-sd-binder --save
 Then you can bind any OMAP client to dash.js.
 
 ```ts
-import { OmapDashjsSDBinder } from ''@ygoto3/omap-dashjs-binder';
+import { OmapDashjsSDBinder } from '@ygoto3/omap-dashjs-sd-binder';
 
 const player = dashjs.MediaPlayer().create();
 const adDisplayContainer = document.getElementById('ad-display-container') as HTMLDivElement;

--- a/packages/dashjs-sd-binder/src/DashjsSDBinder.ts
+++ b/packages/dashjs-sd-binder/src/DashjsSDBinder.ts
@@ -29,28 +29,29 @@ export default class OmapDashjsSDBinder extends OmapDashjsBinder implements IOma
         super(player, adDisplayContainer, adVideoElement);
     }
 
+    protected lastPlayheadTime: number = NaN;
+
     protected override onContentPauseRequested(): void {
         Debug.log("ContentPauseRequested");
         super.onContentPauseRequested();
         if (this.dashjs.isReady()) {
             this._manifest = this.dashjs.getSource();
-            this._currentTime = this.dashjs.time();
+            this.lastPlayheadTime = this.dashjs.time();
         }
     }
 
     protected override onContentResumeRequested(): void {
         Debug.log("ContentResumeRequested");
-        const manifest = this._manifest;
-        if (manifest === undefined) return;
+        if (typeof this._manifest === 'undefined') return;
         if (this.dashjs.isReady()) {
+            const manifest = this.dashjs.getDashAdapter().getMpd().manifest;
             // Reattach the source
             // to resume the content after the ad is played where only a single decoder is available.
-            this.dashjs.attachSource(manifest, this._currentTime);
+            this.dashjs.attachSource(manifest, this.lastPlayheadTime);
         }
         super.onContentResumeRequested();
     }
 
-    private _currentTime: number = NaN;
     private _manifest: string | object | undefined;
 
 }

--- a/packages/dashjs-sd-sustainable-binder/LICENSE
+++ b/packages/dashjs-sd-sustainable-binder/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Yusuke Goto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/dashjs-sd-sustainable-binder/README.md
+++ b/packages/dashjs-sd-sustainable-binder/README.md
@@ -1,0 +1,41 @@
+# @ygoto3/omap-dashjs-sd-binder
+
+## Overview
+
+An OMAP binder implementation to bind [dash.js](https://github.com/Dash-Industry-Forum/dash.js) to an OMAP client.  This binder is implemented to extend [@ygoto3/omap-dashjs-sd-binder](https://github.com/ygoto3/omap/tree/main/packages/dashjs-sd-binder) in order to playback a video stream in a sustainable way.  The binder avoids fetching excessive media data that will be discarded after an ad pod is played, which is what  [@ygoto3/omap-dashjs-sd-binder](https://github.com/ygoto3/omap/tree/main/packages/dashjs-sd-binder) does.
+
+## Documentation
+
+[API document](https://ygoto3.github.io/omap/modules/dashjs_sd_sustainable_binder_src.html) is available.
+
+## Getting Started
+
+To install `@ygoto3/omap-dashjs-sd-sustainable-binder`, run the command below.
+
+```sh
+$ npm install @ygoto3/omap-dashjs-sd-sustainable-binder --save
+```
+
+Then you can bind any OMAP client to dash.js.
+
+```ts
+import { OmapDashjsSDSustainableBinder } from '@ygoto3/omap-dashjs-sd-sustainable-binder';
+
+const player = dashjs.MediaPlayer().create();
+const adDisplayContainer = document.getElementById('ad-display-container') as HTMLDivElement;
+const omapClient = new YourOMAPClient();
+const omapBinder = new OmapDashjsSDSustainableBinder(player, adDisplayContainer);
+omapBinder.bind(omapClient);
+```
+
+## trickyMediaPlayerHandler
+
+You need to use a `trickyMediaPlayerHandler` when you want to seek or to get the duration of the media stream.  Binded by OmapDashjsSDSustainableBinder, a dash.js player cannot neither accurately seek nor return the original duration since the OmapDashjsSDSustainableBinder manipulates the manifest in order to avoid downloading media segments that the dash.js player would redundantly download after playing an ad pod.
+
+```ts
+// Instead of dashjs.seek(10);
+omapBinder.trickyMediaPlayerHandler.seek(10);
+
+// Instead of dashjs.duration;
+omapBinder.trickyMediaPlayerHandler.duration;
+```

--- a/packages/dashjs-sd-sustainable-binder/package.json
+++ b/packages/dashjs-sd-sustainable-binder/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@ygoto3/omap-dashjs-sd-sustainable-binder",
+  "version": "0.0.0",
+  "description": "Open Media Ad Player Dash.js Binder which manipulate the manifest to insert ads",
+  "main": "./dist/dashjs-sd-sustainable-binder/src/index.js",
+  "types": "./dist/dashjs-sd-sustainable-binder/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/dashjs-sd-sustainable-binder/src/index.d.ts",
+      "import": "./dist/dashjs-sd-sustainable-binder/src/index.js",
+      "require": "./dist/dashjs-sd-sustainable-binder/src/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "repository": "https://github.com/ygoto3/omap",
+  "author": "ygoto3<my.important.apes@gmail.com>",
+  "license": "MIT",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "uvu -r ts-node/register tests"
+  },
+  "dependencies": {
+    "@ygoto3/omap-core": "^0.0.1",
+    "@ygoto3/omap-dashjs-sd-binder": "^0.0.2"
+  },
+  "devDependencies": {
+    "dashjs": "^4.7.2",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.3.3",
+    "uvu": "^0.5.6",
+    "webpack": "^5.65.0",
+    "webpack-cli": "^4.9.1",
+    "webpack-merge": "^5.10.0"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/dashjs-sd-sustainable-binder/src/DashjsSDSustainableBinder.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/DashjsSDSustainableBinder.ts
@@ -1,0 +1,187 @@
+import type dashjs from "dashjs";
+import { OmapDashjsSDBinder } from '@ygoto3/omap-dashjs-sd-binder';
+import {
+    OmapClientEvent,
+    type IOmapBinder,
+    type IOmapClient,
+    AdBreak,
+} from '@ygoto3/omap-core';
+import type ITrickyMediaPlayerHandler from './ITrickyMediaPlayerHandler';
+import {
+    MediaSplitPoint,
+    PeriodSplitInfo,
+    deepCopy,
+    periodSplitInfo,
+    shortenPeriodAt,
+} from './manifest-manipulation';
+import type { Manifest, Period } from './dashjs-types';
+import { Debug } from '../../utils/src';
+
+/**
+ * Dash.js binder for OMAP clients.
+ * Use this binder when only a single decoder is available.
+ * ```ts
+ * const player = dashjs.MediaPlayer().create();
+ * const adDisplayContainer = document.getElementById('ad-display-container') as HTMLDivElement;
+ * const adVideoElement = document.getElementById('ad-video') as HTMLVideoElement;
+ * const adTagUrl = 'https://example.com/vmap.xml';
+ * const omapClient = new OmapIABClient(adTagUrl);
+ * const omapBinder = new OmapDashjsSDSustainableBinder(player, adDisplayContainer);
+ * omapBinder.bind(omapClient);
+ * omapBinder.play()
+ *     .then(() => {
+ *         player.initialize(videoElement, 'https://example.com/manifest.mpd', true);
+ *     })
+ *     .catch(() => {
+ *         console.error('adBinder failed to get ready');
+ *     });
+ * ```
+ */
+export default class OmapDashjsSDSustainableBinder extends OmapDashjsSDBinder implements IOmapBinder {
+
+    constructor(player: dashjs.MediaPlayerClass, adDisplayContainer: HTMLElement, adVideoElement?: HTMLVideoElement) {
+        super(player, adDisplayContainer, adVideoElement);
+    }
+
+    get trickyMediaPlayerHandler(): ITrickyMediaPlayerHandler {
+        const me = this;
+
+        return {
+
+            get duration(): number {
+                return me.dashjs.getDashAdapter().getMpd().mediaPresentationDuration;
+            },
+
+            seek: this._seek.bind(this),
+
+        };
+    }
+
+    override bind(omapClient: IOmapClient): void {
+        super.bind(omapClient);
+
+        this.omapClient?.on(OmapClientEvent.LOADED, adBreaks => {
+            Debug.log('OmapClientEvent.LOADED');
+            this._adBreaks = adBreaks;
+        });
+
+        this.omapClient?.on(OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED, () => {
+            Debug.log('OmapClientEvent.AD_POD_INSERTION_REQUEST_FAILED');
+            this._restart(this._seekingPlayheadTimeBeyondAdBreak);
+        });
+
+        // dashjs.MediaPlayer.events.MANIFEST_LOADED === 'manifestLoaded'
+        this.dashjs.on('manifestLoaded', (e: dashjs.ManifestLoadedEvent) => {
+            Debug.log('MANIFEST_LOADED');
+            
+            const points = this._adBreaks
+                .map(adBreak => adBreak.offsetTime)
+                .reduce((acc, val) => {
+                    if (val === 0) return acc;
+                    if (!~acc.indexOf(val)) acc.push(val);
+                    return acc;
+                }, [] as number[])
+                .sort((a, b) => a - b);
+
+            const startTime = isNaN(this.lastPlayheadTime) ? 0 : this.lastPlayheadTime;
+            const pointIndex = points.findIndex(p => p > startTime);
+
+            if (pointIndex === -1) return;
+
+            const mpd = e.data as Manifest;
+            const Period_asArray = mpd.Period_asArray as Period[];
+            this._originalPeriods = deepCopy(Period_asArray);
+            
+            const [psis, periodIndex] = Period_asArray.reduce((acc, period: Period, idx) => {
+                const [psis, foundIndex, prevPeriodEndTime, points, startTime] = acc;
+                if (foundIndex !== -1) return acc;
+                const offsetPoints = points
+                    .map(p => p - prevPeriodEndTime)
+                    .filter(p => p >= 0);
+                const psi = periodSplitInfo(period, offsetPoints);
+                psis.push(psi);
+
+                let newFoundIndex = -1;
+                if (psi.points.length) {
+                    newFoundIndex = idx;
+                }
+                const newAccTime = psi.duration + prevPeriodEndTime;
+                return [psis, newFoundIndex, newAccTime, points, startTime];
+            }, [
+                [] /* period split info list */,
+                -1 /* found index */,
+                0 /* acculated time */,
+                points,
+                startTime,
+            ] as [PeriodSplitInfo[], number, number, number[], number]);
+
+            if (periodIndex === -1) return;
+            const period = Period_asArray[periodIndex];
+            const psi = psis[periodIndex];
+            const mediaSplitPoint = psi.points[pointIndex];
+            if (typeof mediaSplitPoint === 'undefined') return;
+            const shortenedPeriod = shortenPeriodAt(period, mediaSplitPoint);
+            const remainingPeriods = Period_asArray.slice(0, periodIndex);
+            Period_asArray.length = 0;
+            Period_asArray.push(...remainingPeriods, shortenedPeriod);
+
+            this._periodSplitInfoList = psis;
+            this._currentPeriodSplitIndex = periodIndex;
+            this._currentPointIndex = pointIndex;
+        });
+    }
+
+    protected override onContentResumeRequested(): void {
+        Debug.log("ContentResumeRequested");
+        this._restart(this._seekingPlayheadTimeBeyondAdBreak);
+    }
+
+    private _adBreaks: AdBreak[] = [];
+    private _periodSplitInfoList: PeriodSplitInfo[] = [];
+    private _currentPeriodSplitIndex = -1;
+    private _currentPointIndex = -1;
+    private _originalPeriods: Period[] = [];
+    private _seekingPlayheadTimeBeyondAdBreak: number | undefined;
+
+    private _resetManifest(): Manifest {
+        const manifest = this.dashjs.getDashAdapter().getMpd().manifest as Manifest;
+        const originalPeriods = deepCopy(this._originalPeriods);
+        manifest.Period_asArray.length = 0;
+        manifest.Period_asArray.push(...originalPeriods);
+        return manifest;
+    }
+
+    private _restart(startTime?: number): void {
+        if (!this.dashjs.isReady()) return;
+        this.lastPlayheadTime = startTime || this.dashjs.time();
+        const manifest = this._resetManifest();
+        this.dashjs.attachSource(manifest, this.lastPlayheadTime);
+        
+        // reset state
+        this._periodSplitInfoList.length = 0;
+        this._currentPeriodSplitIndex = -1;
+        this._currentPointIndex = -1;
+        this._seekingPlayheadTimeBeyondAdBreak = void 0;
+    }
+
+    private _seek(time: number): void {
+        const splitPeriodStart = this._periodSplitInfoList
+            .slice(0, -1)
+            .reduce((acc, psi) => acc + psi.duration, 0);
+
+        const point: MediaSplitPoint | undefined = this._periodSplitInfoList[this._currentPeriodSplitIndex]?.points[this._currentPointIndex];
+
+        const offestInSecond = point?.video?.offsetInSecond || point?.audio?.offsetInSecond || Number.MAX_SAFE_INTEGER;
+        if (time < splitPeriodStart + offestInSecond) {
+            this.dashjs.seek(time);
+            return;
+        } else if (this.omapClient?.hasAdPodInsertionAt(time)) {
+            this.dashjs.pause();
+            this._seekingPlayheadTimeBeyondAdBreak = time;
+            this.omapClient?.notifyCurrentTime(time);
+        } else {
+            this._restart(time);
+        }
+    }
+
+}

--- a/packages/dashjs-sd-sustainable-binder/src/ITrickyMediaPlayerHandler.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/ITrickyMediaPlayerHandler.ts
@@ -1,0 +1,6 @@
+export default interface ITrickyMediaPlayerHandler {
+
+    duration: number;
+    seek(time: number): void;
+
+}

--- a/packages/dashjs-sd-sustainable-binder/src/dashjs-types.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/dashjs-types.ts
@@ -1,0 +1,120 @@
+export interface Mpd {
+
+    availabilityEndTime: number | Date | null;
+    availabilityStartTime: number | Date | null;
+    manifest: Manifest;
+    maxSegmentDuration: number;
+    mediaPresentationDuration: number;
+    minimumUpdatePeriod: number;
+    publishTime: Date | null;
+    suggestedPresentationDelay: number;
+    timeShiftBufferDepth: number;
+
+}
+
+export interface Manifest {
+
+    PatchLocation: PatchLocation | PatchLocation[];
+    PatchLocation_asArray: PatchLocation[];
+    Period: Period | Period[];
+    Period_asArray: Period[];
+    baseUri: string;
+    loadedTime: Date;
+    mediaPresentationDuration: number;
+    minBufferTime: number;
+    originalUrl: string;
+    profiles: string;
+    protocol: string;
+    type: string;
+    url: string;
+    'xmlns': string;
+    'xmlns:xsi': string;
+    'xsi:schemaLocation': string;
+
+}
+
+export interface Period {
+
+    AdaptationSet: AdaptationSet | AdaptationSet[];
+    AdaptationSet_asArray: AdaptationSet[];
+    BaseURL: string | string[];
+    BaseURL_asArray: string[];
+    duration: number;
+    id?: string;
+
+}
+
+export interface PatchLocation {
+
+    toString: () => string;
+    ttl: number;
+    __children: PatchLocationChild[];
+    __text: string;
+
+}
+
+export interface PatchLocationChild {
+
+    '#text': string;
+
+}
+
+export interface AdaptationSet extends CommonAttributes {
+
+    Representation: Representation | Representation[];
+    Representation_asArray: Representation[];
+    SupplementalProperty: SupplementalProperty | SupplementalProperty[];
+    SupplementalProperty_asArray: SupplementalProperty[];
+    contentType: string;
+    frameRate: string;
+    height: number;
+    id: number;
+    par: string;
+    segmentAlignment: string;
+    width: number;
+
+}
+
+export interface Representation {
+
+    SegmentTemplate: SegmentTemplate;
+    SegmentTemplate_asArray: SegmentTemplate[];
+
+}
+
+export interface SupplementalProperty {
+
+    schemeIdUri: string;
+    value: string;
+
+}
+
+export interface SegmentTemplate {
+
+    SegmentTimeline: SegmentTimeline | SegmentTimeline[];
+    SegmentTimeline_asArray: SegmentTimeline[];
+    timescale: number;
+    presentationTimeOffset: number;
+
+}
+
+export interface SegmentTimeline {
+
+    S: S | S[];
+    S_asArray: S[];
+
+}
+
+export interface S {
+
+    d: number;
+    r?: number;
+    t: number;
+
+}
+
+interface CommonAttributes {
+
+    mimeType?: string;
+
+}

--- a/packages/dashjs-sd-sustainable-binder/src/index.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/index.ts
@@ -1,0 +1,7 @@
+import { default as OmapDashjsSDSustainableBinder } from "./DashjsSDSustainableBinder";
+import type { default as ITrickyMediaPlayerHandler } from "./ITrickyMediaPlayerHandler";
+
+export {
+    OmapDashjsSDSustainableBinder,
+    ITrickyMediaPlayerHandler,
+};

--- a/packages/dashjs-sd-sustainable-binder/src/manifest-manipulation.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/manifest-manipulation.ts
@@ -1,0 +1,299 @@
+import type { Period, S, AdaptationSet, Representation, SegmentTemplate, SegmentTimeline } from './dashjs-types';
+
+
+export function periodSplitInfo(period: Period, points: number[]): PeriodSplitInfo {
+    const [mediaSplitPoints, videoDuration, audioDuration] = mediaSplitPointsInAdaptationSets(points, period.AdaptationSet_asArray);
+
+    const periodSplitInfo: PeriodSplitInfo = {
+        duration: period.duration || Math.max(videoDuration, audioDuration),
+        points: mediaSplitPoints,
+    };
+
+    return periodSplitInfo;
+}
+
+function mediaSplitPointsInAdaptationSets(points: number[], adaptationSets: AdaptationSet[]): [MediaSplitPoint[], number, number] {
+
+    const [
+        videoSegmentTimelineSplitPoints,
+        audioSegmentTimelineSplitPoints,
+        videoDuration,
+        audioDuration,
+    ] = adaptationSets.reduce((acc, adaptationSet) => {
+
+        const [
+            videoSegmentTimelineSplitPoints,
+            audioSegmentTimelineSplitPoints,
+            prevVideoDuration,
+            prevAudioDuration,
+        ] = acc;
+
+        const contentType = contentTypeFromAdaptationSet(adaptationSet);
+
+        if (contentType === 'unknown') {
+            return [
+                videoSegmentTimelineSplitPoints,
+                audioSegmentTimelineSplitPoints,
+                prevVideoDuration,
+                prevAudioDuration,
+            ];
+        }
+
+        const representation = adaptationSet.Representation_asArray[0];
+        const segmentTemplate = segmentTemplateFromRepresentation(representation);
+        const segmentTimeline = segmentTemplate.SegmentTimeline_asArray[0];
+        
+        if (typeof segmentTimeline !== 'undefined') {
+            const timescale = segmentTemplate.timescale || 1;
+
+            const [
+                segmentTimelineSplitPoints,
+                totalDuration,
+            ] = segmentTimelineSplitPointsInSArray(points, segmentTimeline.S_asArray, timescale);
+
+            let videoDuration = prevVideoDuration;
+            let audioDuration = prevAudioDuration;
+            if (contentType === 'video') {
+                videoSegmentTimelineSplitPoints.push(...segmentTimelineSplitPoints);
+                videoDuration = totalDuration / timescale;
+            } else if (contentType === 'audio') {
+                audioSegmentTimelineSplitPoints.push(...segmentTimelineSplitPoints);
+                audioDuration = totalDuration / timescale;
+            }
+
+            return [
+                videoSegmentTimelineSplitPoints,
+                audioSegmentTimelineSplitPoints,
+                videoDuration,
+                audioDuration,
+            ];
+        }
+
+        return [
+            videoSegmentTimelineSplitPoints,
+            audioSegmentTimelineSplitPoints,
+            prevVideoDuration,
+            prevAudioDuration,
+        ];
+    }, [
+        [],
+        [],
+        0,
+        0,
+    ] as [SegmentTimelineSplitPoint[], SegmentTimelineSplitPoint[], number, number]);
+    
+    return [
+        mediaSplitPointsInSegmentTimelineSplitPoints(points, videoSegmentTimelineSplitPoints, audioSegmentTimelineSplitPoints),
+        videoDuration,
+        audioDuration,
+    ];
+}
+
+function segmentTimelineSplitPointsInSArray(
+    points: number[],
+    sArray: S[],
+    timescale: number = 1
+): [SegmentTimelineSplitPoint[], number, number] {
+    return sArray.reduce((acc, s, idx) => {
+        const [
+            prevSegmentTimelineSplitPoints,
+            offsetTime,
+            timescale,
+        ] = acc;
+        
+        const [segmentTimelineSplitPoints, endTime] = pointsInS(points, s, offsetTime, timescale, idx);
+        prevSegmentTimelineSplitPoints.push(...segmentTimelineSplitPoints);
+        
+        return [prevSegmentTimelineSplitPoints, endTime, timescale];
+    },
+    [
+        [],
+        0 /* offsetTime */,
+        timescale,
+    ] as [SegmentTimelineSplitPoint[], number, number]);
+}
+
+function pointsInS(
+    points: number[],
+    s: S,
+    offset: number,
+    timescale: number,
+    segmentIndex: number,
+): [SegmentTimelineSplitPoint[], number] {
+    const repeat = s.r || 0;
+    const duration = s.d * (repeat + 1);
+    const startTime = s.t || offset;
+    const endTime = offset + duration;
+
+    const [
+        segmentTimelineSplitPoints,
+        accumulatedDuration,
+    ] = points.reduce((acc, point) => {
+        const [
+            segmentTimelineSplitPoints,
+            _,
+            timescale,
+        ] = acc;
+
+        const pointInScale = point * timescale;
+        
+        if (offset <= pointInScale && pointInScale <= endTime) {
+            let repeatNumber = 0;
+            if (s.r && s.r > 0) {
+                const delta = pointInScale - offset;
+                repeatNumber = Math.floor(delta / s.d);
+            }
+            const segmentTimelineSplitPoint: SegmentTimelineSplitPoint = {
+                offsetInSecond: point,
+                type: 'SegmentTimeline',
+                index: segmentIndex,
+                repeat: repeatNumber,
+            };
+            segmentTimelineSplitPoints.push(segmentTimelineSplitPoint);
+        }
+
+        return [segmentTimelineSplitPoints, endTime, timescale, segmentIndex];
+    }, [
+        [],
+        offset,
+        timescale,
+        segmentIndex,
+    ] as [
+        SegmentTimelineSplitPoint[], number, number, number
+    ]);
+
+    return [segmentTimelineSplitPoints, accumulatedDuration];
+}
+
+function mediaSplitPointsInSegmentTimelineSplitPoints(points: number[], videoSegmentTimelineSplitPoints: SegmentTimelineSplitPoint[], audioSegmentTimelineSplitPoints: SegmentTimelineSplitPoint[]): MediaSplitPoint[] {
+    const [mediaSplitPoints] = videoSegmentTimelineSplitPoints.reduce(
+        (acc, videoSegmentTimelineSplitPoint, idx) => {
+            const [mediaSplitPoints, audioSegmentTimelineSplitPoints] = acc;
+        
+            const audioSegmentTimelineSplitPoint = audioSegmentTimelineSplitPoints[idx];
+            if (typeof audioSegmentTimelineSplitPoint !== 'undefined') {
+                const mediaSplitPoint: MediaSplitPoint = {
+                    video: videoSegmentTimelineSplitPoint,
+                    audio: audioSegmentTimelineSplitPoint,
+                }
+                mediaSplitPoints[idx] = mediaSplitPoint;
+            }
+
+            return acc;
+    }, [[], audioSegmentTimelineSplitPoints] as [MediaSplitPoint[], SegmentTimelineSplitPoint[]]);
+    
+    return mediaSplitPoints;
+}
+
+export function shortenPeriodAt(period: Period, mediaSplitPoint: MediaSplitPoint): Period {
+    const { video, audio } = mediaSplitPoint;
+    if (typeof video === 'undefined' || typeof audio === 'undefined') return period;
+    
+    const clonedAdaptationSets = deepCopy(period.AdaptationSet_asArray);
+    const [
+        adaptationSets,
+    ] = clonedAdaptationSets.reduce((acc, adaptationSet) => {
+        const [
+            adaptationSets,
+            prevVideo,
+            prevAudio,
+        ] = acc;
+
+        const contentType = contentTypeFromAdaptationSet(adaptationSet);
+        if (contentType === 'unknown') return acc;
+
+        const splitPoint = contentType === 'video' ? video : audio;
+
+        const [ representations, _ ] =
+            adaptationSet.Representation_asArray.reduce((acc, representation) => {
+                const [ representations, splitPoint ] = acc;
+
+                const segmentTemplate = segmentTemplateFromRepresentation(representation);
+                const segmentTimeline = segmentTemplate.SegmentTimeline_asArray[0];
+
+                [segmentTemplate.SegmentTimeline_asArray[0], segmentTemplate.SegmentTimeline as SegmentTimeline].forEach(segmentTimeline => {
+                    const targetS = segmentTimeline.S_asArray[splitPoint.index];
+                    if (typeof targetS === 'undefined') return [representations, splitPoint] as [Representation[], SegmentTimelineSplitPoint];
+                    if (splitPoint.repeat === 0) {
+                        delete targetS.r;
+                    } else if (targetS.r && targetS.r > 0) {
+                        targetS.r =  splitPoint.repeat;
+                    }
+                    segmentTimeline.S_asArray.length = splitPoint.index + 1;
+                });
+
+                representations.push(representation);
+
+                return [representations, splitPoint] as [Representation[], SegmentTimelineSplitPoint];
+            }, [
+                [],
+                splitPoint,
+            ] as [Representation[], SegmentTimelineSplitPoint]);
+
+        adaptationSet.Representation_asArray.length = 0;
+        adaptationSet.Representation_asArray.push(...representations);
+
+        adaptationSets.push(adaptationSet);
+        
+        return [
+            adaptationSets,
+            video,
+            audio,
+        ];
+    }, [
+        [],
+        video,
+        audio,
+    ] as [AdaptationSet[], SegmentTimelineSplitPoint, SegmentTimelineSplitPoint]);
+
+
+    period.AdaptationSet_asArray.length = 0;
+    period.AdaptationSet_asArray.push(...adaptationSets);
+    return period;
+};
+
+export function deepCopy<T>(obj: T): T {
+    if (typeof structuredClone === 'function') {
+        try {
+            return structuredClone(obj);
+        } catch (e) {
+            console.warn('structuredClone is not supported, using JSON.parse(JSON.stringify())');
+        }
+    }
+    return JSON.parse(JSON.stringify(obj)) as T;
+}
+
+export function contentTypeFromAdaptationSet(adaptationSet: AdaptationSet): 'video' | 'audio' | 'unknown' {
+    if (adaptationSet.contentType === 'video') return 'video';
+    else if (adaptationSet.contentType === 'audio') return 'audio';
+    else if (typeof adaptationSet.mimeType !== 'undefined') {
+        if (adaptationSet.mimeType.startsWith('video')) return 'video';
+        else if (adaptationSet.mimeType.startsWith('audio')) return 'audio';
+        else return 'unknown';
+    }
+    return 'unknown';
+}
+
+export function segmentTemplateFromRepresentation(representation: Representation): SegmentTemplate {
+    return Array.isArray(representation.SegmentTemplate_asArray) ? representation.SegmentTemplate_asArray[0] : representation.SegmentTemplate;
+}
+
+interface SplitPoint {
+    type: 'SegmentTimeline';
+    offsetInSecond: number;
+}
+
+type SegmentTimelineSplitPoint = SplitPoint & {
+    index: number;
+    repeat: number;
+};
+
+export interface MediaSplitPoint {
+    video?: SegmentTimelineSplitPoint;
+    audio?: SegmentTimelineSplitPoint;
+}
+
+export interface PeriodSplitInfo {
+    duration: number;
+    points: MediaSplitPoint[];
+}

--- a/packages/dashjs-sd-sustainable-binder/tests/manifest-manipulation.test.ts
+++ b/packages/dashjs-sd-sustainable-binder/tests/manifest-manipulation.test.ts
@@ -1,0 +1,95 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import { periodSplitInfo, shortenPeriodAt } from '../src/manifest-manipulation';
+import testPeriodAdaptationSetContentType from './test-period-adaptationset-contenttype';
+import testPeriodAdaptationSetMimeType from './test-period-adaptationset-mimetype';
+
+const test = suite('manifest manipulation test');
+
+test("periodSplitInfo a period containing AdaptationSet's contentType", () => {
+    const psi = periodSplitInfo(testPeriodAdaptationSetContentType, [5, 10, 30]);
+    
+    assert.is(psi.duration, 19.498666666666665);
+    assert.is(psi.points.length, 2);
+
+    assert.is(psi.points[0].video?.index, 0);
+    assert.is(psi.points[0].video?.offsetInSecond, 5);
+    assert.is(psi.points[0].video?.repeat, 0);
+    assert.is(psi.points[0].video?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[0].audio?.index, 0);
+    assert.is(psi.points[0].audio?.offsetInSecond, 5);
+    assert.is(psi.points[0].audio?.repeat, 0);
+    assert.is(psi.points[0].audio?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[1].video?.index, 0);
+    assert.is(psi.points[1].video?.offsetInSecond, 10);
+    assert.is(psi.points[1].video?.repeat, 1);
+    assert.is(psi.points[1].video?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[1].audio?.index, 1);
+    assert.is(psi.points[1].audio?.offsetInSecond, 10);
+    assert.is(psi.points[1].audio?.repeat, 0);
+    assert.is(psi.points[1].audio?.type, 'SegmentTimeline');
+
+    const shortenedPeriod = shortenPeriodAt(testPeriodAdaptationSetContentType, psi.points[0]);
+
+    // video
+    let SegmentTimeline = shortenedPeriod.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0];
+    assert.is(SegmentTimeline.S_asArray.length, psi.points[0].video!.index + 1);
+    assert.is(SegmentTimeline.S_asArray[0].t, testPeriodAdaptationSetContentType.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].t);
+    assert.is(SegmentTimeline.S_asArray[0].d, testPeriodAdaptationSetContentType.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].d);
+    assert.is(SegmentTimeline.S_asArray[0].r || 0, psi.points[0].video!.repeat);
+
+    // audio
+    SegmentTimeline = shortenedPeriod.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0];
+    assert.is(SegmentTimeline.S_asArray.length, psi.points[0].audio!.index + 1);
+    assert.is(SegmentTimeline.S_asArray[0].t, testPeriodAdaptationSetContentType.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].t);
+    assert.is(SegmentTimeline.S_asArray[0].d, testPeriodAdaptationSetContentType.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].d);
+    assert.is(SegmentTimeline.S_asArray[0].r || 0, psi.points[0].audio!.repeat);
+});
+
+test("periodSplitInfo a period containing AdaptationSet's contentType", () => {
+    const psi = periodSplitInfo(testPeriodAdaptationSetMimeType, [5, 10, 30]);
+    
+    assert.is(psi.duration, 19.498666666666665);
+    assert.is(psi.points.length, 2);
+
+    assert.is(psi.points[0].video?.index, 0);
+    assert.is(psi.points[0].video?.offsetInSecond, 5);
+    assert.is(psi.points[0].video?.repeat, 0);
+    assert.is(psi.points[0].video?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[0].audio?.index, 0);
+    assert.is(psi.points[0].audio?.offsetInSecond, 5);
+    assert.is(psi.points[0].audio?.repeat, 0);
+    assert.is(psi.points[0].audio?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[1].video?.index, 0);
+    assert.is(psi.points[1].video?.offsetInSecond, 10);
+    assert.is(psi.points[1].video?.repeat, 1);
+    assert.is(psi.points[1].video?.type, 'SegmentTimeline');
+
+    assert.is(psi.points[1].audio?.index, 1);
+    assert.is(psi.points[1].audio?.offsetInSecond, 10);
+    assert.is(psi.points[1].audio?.repeat, 0);
+    assert.is(psi.points[1].audio?.type, 'SegmentTimeline');
+
+    const shortenedPeriod = shortenPeriodAt(testPeriodAdaptationSetContentType, psi.points[0]);
+
+    // video
+    let SegmentTimeline = shortenedPeriod.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0];
+    assert.is(SegmentTimeline.S_asArray.length, psi.points[0].video!.index + 1);
+    assert.is(SegmentTimeline.S_asArray[0].t, testPeriodAdaptationSetMimeType.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].t);
+    assert.is(SegmentTimeline.S_asArray[0].d, testPeriodAdaptationSetMimeType.AdaptationSet_asArray[0].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].d);
+    assert.is(SegmentTimeline.S_asArray[0].r || 0, psi.points[0].video!.repeat);
+
+    // audio
+    SegmentTimeline = shortenedPeriod.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0];
+    assert.is(SegmentTimeline.S_asArray.length, psi.points[0].audio!.index + 1);
+    assert.is(SegmentTimeline.S_asArray[0].t, testPeriodAdaptationSetMimeType.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].t);
+    assert.is(SegmentTimeline.S_asArray[0].d, testPeriodAdaptationSetMimeType.AdaptationSet_asArray[1].Representation_asArray[0].SegmentTemplate_asArray[0].SegmentTimeline_asArray[0].S_asArray[0].d);
+    assert.is(SegmentTimeline.S_asArray[0].r || 0, psi.points[0].audio!.repeat);
+});
+
+test.run();

--- a/packages/dashjs-sd-sustainable-binder/tests/test-period-adaptationset-contenttype.ts
+++ b/packages/dashjs-sd-sustainable-binder/tests/test-period-adaptationset-contenttype.ts
@@ -1,0 +1,9952 @@
+import type { Period } from "../src/dashjs-types";
+
+const period = {
+    "BaseURL": "/media/video_1/",
+    "BaseURL_asArray": [
+      "/media/video_1/"
+    ],
+    "AdaptationSet": [
+      {
+        "SupplementalProperty": {
+          "__children": [],
+          "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+          "value": "1"
+        },
+        "SupplementalProperty_asArray": [
+          {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        ],
+        "Representation": {
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 25,
+            "initialization": "video/init.mp4",
+            "media": "video/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "0",
+          "bandwidth": 5508711,
+          "codecs": "avc1.640028",
+          "mimeType": "video/mp4",
+          "sar": "1:1",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        },
+        "Representation_asArray": [
+          {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          }
+        ],
+        "__children": [
+          {
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          {
+            "Representation": {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          }
+        ],
+        "id": 0,
+        "contentType": "video",
+        "width": 1920,
+        "height": 1080,
+        "frameRate": "25/1",
+        "segmentAlignment": "true",
+        "par": "16:9"
+      },
+      {
+        "Representation": {
+          "AudioChannelConfiguration": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+            "value": "2"
+          },
+          "AudioChannelConfiguration_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            }
+          ],
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 48000,
+            "initialization": "audio/init.mp4",
+            "media": "audio/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            },
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "1",
+          "bandwidth": 138757,
+          "codecs": "mp4a.40.2",
+          "mimeType": "audio/mp4",
+          "audioSamplingRate": 48000
+        },
+        "Representation_asArray": [
+          {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          }
+        ],
+        "__children": [
+          {
+            "Representation": {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          }
+        ],
+        "id": 1,
+        "contentType": "audio",
+        "segmentAlignment": "true"
+      }
+    ],
+    "AdaptationSet_asArray": [
+      {
+        "SupplementalProperty": {
+          "__children": [],
+          "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+          "value": "1"
+        },
+        "SupplementalProperty_asArray": [
+          {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        ],
+        "Representation": {
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 25,
+            "initialization": "video/init.mp4",
+            "media": "video/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "0",
+          "bandwidth": 5508711,
+          "codecs": "avc1.640028",
+          "mimeType": "video/mp4",
+          "sar": "1:1",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        },
+        "Representation_asArray": [
+          {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          }
+        ],
+        "__children": [
+          {
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          {
+            "Representation": {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          }
+        ],
+        "id": 0,
+        "contentType": "video",
+        "width": 1920,
+        "height": 1080,
+        "frameRate": "25/1",
+        "segmentAlignment": "true",
+        "par": "16:9"
+      },
+      {
+        "Representation": {
+          "AudioChannelConfiguration": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+            "value": "2"
+          },
+          "AudioChannelConfiguration_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            }
+          ],
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 48000,
+            "initialization": "audio/init.mp4",
+            "media": "audio/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            },
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "1",
+          "bandwidth": 138757,
+          "codecs": "mp4a.40.2",
+          "mimeType": "audio/mp4",
+          "audioSamplingRate": 48000
+        },
+        "Representation_asArray": [
+          {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          }
+        ],
+        "__children": [
+          {
+            "Representation": {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          }
+        ],
+        "id": 1,
+        "contentType": "audio",
+        "segmentAlignment": "true"
+      }
+    ],
+    "__children": [
+      {
+        "BaseURL": "/media/video_1/"
+      },
+      {
+        "AdaptationSet": {
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          },
+          "SupplementalProperty_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          ],
+          "Representation": {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          "Representation_asArray": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          ],
+          "__children": [
+            {
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            },
+            {
+              "Representation": {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                },
+                "SegmentTemplate_asArray": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTemplate": {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      },
+                      "SegmentTimeline_asArray": [
+                        {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "SegmentTimeline": {
+                            "S": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              },
+                              {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            ],
+                            "S_asArray": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              },
+                              {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            ],
+                            "__children": [
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 0,
+                                  "d": 152,
+                                  "r": 2
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 456,
+                                  "d": 31
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "timescale": 25,
+                      "initialization": "video/init.mp4",
+                      "media": "video/$Number$.m4s",
+                      "startNumber": 1
+                    }
+                  }
+                ],
+                "id": "0",
+                "bandwidth": 5508711,
+                "codecs": "avc1.640028",
+                "mimeType": "video/mp4",
+                "sar": "1:1",
+                "width": 1920,
+                "height": 1080,
+                "frameRate": "25/1",
+                "SupplementalProperty": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                  "value": "1"
+                }
+              }
+            }
+          ],
+          "id": 0,
+          "contentType": "video",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "segmentAlignment": "true",
+          "par": "16:9"
+        }
+      },
+      {
+        "AdaptationSet": {
+          "Representation": {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          },
+          "Representation_asArray": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          ],
+          "__children": [
+            {
+              "Representation": {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                },
+                "AudioChannelConfiguration_asArray": [
+                  {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                ],
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                },
+                "SegmentTemplate_asArray": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                ],
+                "__children": [
+                  {
+                    "AudioChannelConfiguration": {
+                      "__children": [],
+                      "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                      "value": "2"
+                    }
+                  },
+                  {
+                    "SegmentTemplate": {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      },
+                      "SegmentTimeline_asArray": [
+                        {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "SegmentTimeline": {
+                            "S": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              },
+                              {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              },
+                              {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            ],
+                            "S_asArray": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              },
+                              {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              },
+                              {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            ],
+                            "__children": [
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 0,
+                                  "d": 288768
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 288768,
+                                  "d": 287744,
+                                  "r": 1
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 864256,
+                                  "d": 71680
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "timescale": 48000,
+                      "initialization": "audio/init.mp4",
+                      "media": "audio/$Number$.m4s",
+                      "startNumber": 1
+                    }
+                  }
+                ],
+                "id": "1",
+                "bandwidth": 138757,
+                "codecs": "mp4a.40.2",
+                "mimeType": "audio/mp4",
+                "audioSamplingRate": 48000
+              }
+            }
+          ],
+          "id": 1,
+          "contentType": "audio",
+          "segmentAlignment": "true"
+        }
+      }
+    ],
+    "id": "1",
+    "duration": 19.498666666666665
+  } as any;
+
+export default period as Period;

--- a/packages/dashjs-sd-sustainable-binder/tests/test-period-adaptationset-mimetype.ts
+++ b/packages/dashjs-sd-sustainable-binder/tests/test-period-adaptationset-mimetype.ts
@@ -1,0 +1,9952 @@
+import type { Period } from "../src/dashjs-types";
+
+const period = {
+    "BaseURL": "/media/video_1/",
+    "BaseURL_asArray": [
+      "/media/video_1/"
+    ],
+    "AdaptationSet": [
+      {
+        "SupplementalProperty": {
+          "__children": [],
+          "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+          "value": "1"
+        },
+        "SupplementalProperty_asArray": [
+          {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        ],
+        "Representation": {
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 25,
+            "initialization": "video/init.mp4",
+            "media": "video/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "0",
+          "bandwidth": 5508711,
+          "codecs": "avc1.640028",
+          "mimeType": "video/mp4",
+          "sar": "1:1",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        },
+        "Representation_asArray": [
+          {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          }
+        ],
+        "__children": [
+          {
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          {
+            "Representation": {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          }
+        ],
+        "id": 0,
+        "mimeType": "video/mp4",
+        "width": 1920,
+        "height": 1080,
+        "frameRate": "25/1",
+        "segmentAlignment": "true",
+        "par": "16:9"
+      },
+      {
+        "Representation": {
+          "AudioChannelConfiguration": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+            "value": "2"
+          },
+          "AudioChannelConfiguration_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            }
+          ],
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 48000,
+            "initialization": "audio/init.mp4",
+            "media": "audio/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            },
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "1",
+          "bandwidth": 138757,
+          "codecs": "mp4a.40.2",
+          "mimeType": "audio/mp4",
+          "audioSamplingRate": 48000
+        },
+        "Representation_asArray": [
+          {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          }
+        ],
+        "__children": [
+          {
+            "Representation": {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          }
+        ],
+        "id": 1,
+        "mimeType": "audio/mp4",
+        "segmentAlignment": "true"
+      }
+    ],
+    "AdaptationSet_asArray": [
+      {
+        "SupplementalProperty": {
+          "__children": [],
+          "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+          "value": "1"
+        },
+        "SupplementalProperty_asArray": [
+          {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        ],
+        "Representation": {
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 152,
+                  "r": 2
+                },
+                {
+                  "__children": [],
+                  "t": 456,
+                  "d": 31
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 25,
+            "initialization": "video/init.mp4",
+            "media": "video/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "0",
+          "bandwidth": 5508711,
+          "codecs": "avc1.640028",
+          "mimeType": "video/mp4",
+          "sar": "1:1",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          }
+        },
+        "Representation_asArray": [
+          {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          }
+        ],
+        "__children": [
+          {
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          {
+            "Representation": {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          }
+        ],
+        "id": 0,
+        "mimeType": "video/mp4",
+        "width": 1920,
+        "height": 1080,
+        "frameRate": "25/1",
+        "segmentAlignment": "true",
+        "par": "16:9"
+      },
+      {
+        "Representation": {
+          "AudioChannelConfiguration": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+            "value": "2"
+          },
+          "AudioChannelConfiguration_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            }
+          ],
+          "SegmentTemplate": {
+            "SegmentTimeline": {
+              "S": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "S_asArray": [
+                {
+                  "__children": [],
+                  "t": 0,
+                  "d": 288768
+                },
+                {
+                  "__children": [],
+                  "t": 288768,
+                  "d": 287744,
+                  "r": 1
+                },
+                {
+                  "__children": [],
+                  "t": 864256,
+                  "d": 71680
+                }
+              ],
+              "__children": [
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  }
+                },
+                {
+                  "S": {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                }
+              ]
+            },
+            "SegmentTimeline_asArray": [
+              {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              }
+            ],
+            "timescale": 48000,
+            "initialization": "audio/init.mp4",
+            "media": "audio/$Number$.m4s",
+            "startNumber": 1
+          },
+          "SegmentTemplate_asArray": [
+            {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            }
+          ],
+          "__children": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            },
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            }
+          ],
+          "id": "1",
+          "bandwidth": 138757,
+          "codecs": "mp4a.40.2",
+          "mimeType": "audio/mp4",
+          "audioSamplingRate": 48000
+        },
+        "Representation_asArray": [
+          {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          }
+        ],
+        "__children": [
+          {
+            "Representation": {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          }
+        ],
+        "id": 1,
+        "mimeType": "audio/mp4",
+        "segmentAlignment": "true"
+      }
+    ],
+    "__children": [
+      {
+        "BaseURL": "/media/video_1/"
+      },
+      {
+        "AdaptationSet": {
+          "SupplementalProperty": {
+            "__children": [],
+            "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+            "value": "1"
+          },
+          "SupplementalProperty_asArray": [
+            {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          ],
+          "Representation": {
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 152,
+                    "r": 2
+                  },
+                  {
+                    "__children": [],
+                    "t": 456,
+                    "d": 31
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 25,
+              "initialization": "video/init.mp4",
+              "media": "video/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "0",
+            "bandwidth": 5508711,
+            "codecs": "avc1.640028",
+            "mimeType": "video/mp4",
+            "sar": "1:1",
+            "width": 1920,
+            "height": 1080,
+            "frameRate": "25/1",
+            "SupplementalProperty": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+              "value": "1"
+            }
+          },
+          "Representation_asArray": [
+            {
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 152,
+                      "r": 2
+                    },
+                    {
+                      "__children": [],
+                      "t": 456,
+                      "d": 31
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 25,
+                "initialization": "video/init.mp4",
+                "media": "video/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "0",
+              "bandwidth": 5508711,
+              "codecs": "avc1.640028",
+              "mimeType": "video/mp4",
+              "sar": "1:1",
+              "width": 1920,
+              "height": 1080,
+              "frameRate": "25/1",
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            }
+          ],
+          "__children": [
+            {
+              "SupplementalProperty": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                "value": "1"
+              }
+            },
+            {
+              "Representation": {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 152,
+                        "r": 2
+                      },
+                      {
+                        "__children": [],
+                        "t": 456,
+                        "d": 31
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 25,
+                  "initialization": "video/init.mp4",
+                  "media": "video/$Number$.m4s",
+                  "startNumber": 1
+                },
+                "SegmentTemplate_asArray": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 152,
+                          "r": 2
+                        },
+                        {
+                          "__children": [],
+                          "t": 456,
+                          "d": 31
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 25,
+                    "initialization": "video/init.mp4",
+                    "media": "video/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTemplate": {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 152,
+                            "r": 2
+                          },
+                          {
+                            "__children": [],
+                            "t": 456,
+                            "d": 31
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          }
+                        ]
+                      },
+                      "SegmentTimeline_asArray": [
+                        {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 152,
+                              "r": 2
+                            },
+                            {
+                              "__children": [],
+                              "t": 456,
+                              "d": 31
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "SegmentTimeline": {
+                            "S": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              },
+                              {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            ],
+                            "S_asArray": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 152,
+                                "r": 2
+                              },
+                              {
+                                "__children": [],
+                                "t": 456,
+                                "d": 31
+                              }
+                            ],
+                            "__children": [
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 0,
+                                  "d": 152,
+                                  "r": 2
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 456,
+                                  "d": 31
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "timescale": 25,
+                      "initialization": "video/init.mp4",
+                      "media": "video/$Number$.m4s",
+                      "startNumber": 1
+                    }
+                  }
+                ],
+                "id": "0",
+                "bandwidth": 5508711,
+                "codecs": "avc1.640028",
+                "mimeType": "video/mp4",
+                "sar": "1:1",
+                "width": 1920,
+                "height": 1080,
+                "frameRate": "25/1",
+                "SupplementalProperty": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:mpegB:cicp:TransferCharacteristics",
+                  "value": "1"
+                }
+              }
+            }
+          ],
+          "id": 0,
+          "mimeType": "video/mp4",
+          "width": 1920,
+          "height": 1080,
+          "frameRate": "25/1",
+          "segmentAlignment": "true",
+          "par": "16:9"
+        }
+      },
+      {
+        "AdaptationSet": {
+          "Representation": {
+            "AudioChannelConfiguration": {
+              "__children": [],
+              "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+              "value": "2"
+            },
+            "AudioChannelConfiguration_asArray": [
+              {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              }
+            ],
+            "SegmentTemplate": {
+              "SegmentTimeline": {
+                "S": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "S_asArray": [
+                  {
+                    "__children": [],
+                    "t": 0,
+                    "d": 288768
+                  },
+                  {
+                    "__children": [],
+                    "t": 288768,
+                    "d": 287744,
+                    "r": 1
+                  },
+                  {
+                    "__children": [],
+                    "t": 864256,
+                    "d": 71680
+                  }
+                ],
+                "__children": [
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    }
+                  },
+                  {
+                    "S": {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  }
+                ]
+              },
+              "SegmentTimeline_asArray": [
+                {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                }
+              ],
+              "__children": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                }
+              ],
+              "timescale": 48000,
+              "initialization": "audio/init.mp4",
+              "media": "audio/$Number$.m4s",
+              "startNumber": 1
+            },
+            "SegmentTemplate_asArray": [
+              {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              }
+            ],
+            "__children": [
+              {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              },
+              {
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              }
+            ],
+            "id": "1",
+            "bandwidth": 138757,
+            "codecs": "mp4a.40.2",
+            "mimeType": "audio/mp4",
+            "audioSamplingRate": 48000
+          },
+          "Representation_asArray": [
+            {
+              "AudioChannelConfiguration": {
+                "__children": [],
+                "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                "value": "2"
+              },
+              "AudioChannelConfiguration_asArray": [
+                {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                }
+              ],
+              "SegmentTemplate": {
+                "SegmentTimeline": {
+                  "S": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "S_asArray": [
+                    {
+                      "__children": [],
+                      "t": 0,
+                      "d": 288768
+                    },
+                    {
+                      "__children": [],
+                      "t": 288768,
+                      "d": 287744,
+                      "r": 1
+                    },
+                    {
+                      "__children": [],
+                      "t": 864256,
+                      "d": 71680
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      }
+                    },
+                    {
+                      "S": {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    }
+                  ]
+                },
+                "SegmentTimeline_asArray": [
+                  {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  }
+                ],
+                "__children": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "timescale": 48000,
+                "initialization": "audio/init.mp4",
+                "media": "audio/$Number$.m4s",
+                "startNumber": 1
+              },
+              "SegmentTemplate_asArray": [
+                {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                }
+              ],
+              "__children": [
+                {
+                  "AudioChannelConfiguration": {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                },
+                {
+                  "SegmentTemplate": {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                }
+              ],
+              "id": "1",
+              "bandwidth": 138757,
+              "codecs": "mp4a.40.2",
+              "mimeType": "audio/mp4",
+              "audioSamplingRate": 48000
+            }
+          ],
+          "__children": [
+            {
+              "Representation": {
+                "AudioChannelConfiguration": {
+                  "__children": [],
+                  "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                  "value": "2"
+                },
+                "AudioChannelConfiguration_asArray": [
+                  {
+                    "__children": [],
+                    "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                    "value": "2"
+                  }
+                ],
+                "SegmentTemplate": {
+                  "SegmentTimeline": {
+                    "S": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "S_asArray": [
+                      {
+                        "__children": [],
+                        "t": 0,
+                        "d": 288768
+                      },
+                      {
+                        "__children": [],
+                        "t": 288768,
+                        "d": 287744,
+                        "r": 1
+                      },
+                      {
+                        "__children": [],
+                        "t": 864256,
+                        "d": 71680
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        }
+                      },
+                      {
+                        "S": {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      }
+                    ]
+                  },
+                  "SegmentTimeline_asArray": [
+                    {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    }
+                  ],
+                  "__children": [
+                    {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "timescale": 48000,
+                  "initialization": "audio/init.mp4",
+                  "media": "audio/$Number$.m4s",
+                  "startNumber": 1
+                },
+                "SegmentTemplate_asArray": [
+                  {
+                    "SegmentTimeline": {
+                      "S": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "S_asArray": [
+                        {
+                          "__children": [],
+                          "t": 0,
+                          "d": 288768
+                        },
+                        {
+                          "__children": [],
+                          "t": 288768,
+                          "d": 287744,
+                          "r": 1
+                        },
+                        {
+                          "__children": [],
+                          "t": 864256,
+                          "d": 71680
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          }
+                        },
+                        {
+                          "S": {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        }
+                      ]
+                    },
+                    "SegmentTimeline_asArray": [
+                      {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      }
+                    ],
+                    "__children": [
+                      {
+                        "SegmentTimeline": {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "timescale": 48000,
+                    "initialization": "audio/init.mp4",
+                    "media": "audio/$Number$.m4s",
+                    "startNumber": 1
+                  }
+                ],
+                "__children": [
+                  {
+                    "AudioChannelConfiguration": {
+                      "__children": [],
+                      "schemeIdUri": "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",
+                      "value": "2"
+                    }
+                  },
+                  {
+                    "SegmentTemplate": {
+                      "SegmentTimeline": {
+                        "S": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "S_asArray": [
+                          {
+                            "__children": [],
+                            "t": 0,
+                            "d": 288768
+                          },
+                          {
+                            "__children": [],
+                            "t": 288768,
+                            "d": 287744,
+                            "r": 1
+                          },
+                          {
+                            "__children": [],
+                            "t": 864256,
+                            "d": 71680
+                          }
+                        ],
+                        "__children": [
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            }
+                          },
+                          {
+                            "S": {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          }
+                        ]
+                      },
+                      "SegmentTimeline_asArray": [
+                        {
+                          "S": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "S_asArray": [
+                            {
+                              "__children": [],
+                              "t": 0,
+                              "d": 288768
+                            },
+                            {
+                              "__children": [],
+                              "t": 288768,
+                              "d": 287744,
+                              "r": 1
+                            },
+                            {
+                              "__children": [],
+                              "t": 864256,
+                              "d": 71680
+                            }
+                          ],
+                          "__children": [
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              }
+                            },
+                            {
+                              "S": {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            }
+                          ]
+                        }
+                      ],
+                      "__children": [
+                        {
+                          "SegmentTimeline": {
+                            "S": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              },
+                              {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              },
+                              {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            ],
+                            "S_asArray": [
+                              {
+                                "__children": [],
+                                "t": 0,
+                                "d": 288768
+                              },
+                              {
+                                "__children": [],
+                                "t": 288768,
+                                "d": 287744,
+                                "r": 1
+                              },
+                              {
+                                "__children": [],
+                                "t": 864256,
+                                "d": 71680
+                              }
+                            ],
+                            "__children": [
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 0,
+                                  "d": 288768
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 288768,
+                                  "d": 287744,
+                                  "r": 1
+                                }
+                              },
+                              {
+                                "S": {
+                                  "__children": [],
+                                  "t": 864256,
+                                  "d": 71680
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "timescale": 48000,
+                      "initialization": "audio/init.mp4",
+                      "media": "audio/$Number$.m4s",
+                      "startNumber": 1
+                    }
+                  }
+                ],
+                "id": "1",
+                "bandwidth": 138757,
+                "codecs": "mp4a.40.2",
+                "mimeType": "audio/mp4",
+                "audioSamplingRate": 48000
+              }
+            }
+          ],
+          "id": 1,
+          "mimeType": "audio/mp4",
+          "segmentAlignment": "true"
+        }
+      }
+    ],
+    "id": "1",
+    "duration": 19.498666666666665
+  } as any;
+
+export default period as Period;

--- a/packages/dashjs-sd-sustainable-binder/tsconfig.json
+++ b/packages/dashjs-sd-sustainable-binder/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "module": "NodeNext",
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDirs": ["./src", "../utils/src"],
+    "strict": true,
+    "moduleResolution": "NodeNext",
+    "baseUrl": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "importsNotUsedAsValues": "error",
+    "ignoreDeprecations": "5.0"
+  },
+  "include": ["src/**/*.ts", "../utils/src/**/*.ts"],
+  "exclude": ["dist", "node_modules"],
+  "compileOnSave": false
+}

--- a/packages/dashjs-sd-sustainable-binder/webpack.prod.js
+++ b/packages/dashjs-sd-sustainable-binder/webpack.prod.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const { merge } = require('webpack-merge');
+const common = require('../../webpack.common.js');
+
+module.exports = merge(common, {
+    mode: 'production',
+    entry: {
+        bundle: './src/index.ts'
+    },
+    output: {
+        path: path.join(__dirname, 'dist'),
+        filename: '[name].js'
+    },
+});


### PR DESCRIPTION
This adds a new package `dashjs-sd-sustainable-binder`.  This binder is implemented to extend [@ygoto3/omap-dashjs-sd-binder](https://github.com/ygoto3/omap/tree/main/packages/dashjs-sd-binder) in order to playback a video stream in a sustainable way.  The binder avoids fetching excessive media data that will be discarded after an ad pod is played, which is what  [@ygoto3/omap-dashjs-sd-binder](https://github.com/ygoto3/omap/tree/main/packages/dashjs-sd-binder) does