### PR TITLE
docs: Fix dashjs-sd-sustainable-binder doc

### DIFF
--- a/packages/dashjs-sd-sustainable-binder/README.md
+++ b/packages/dashjs-sd-sustainable-binder/README.md
@@ -39,3 +39,13 @@ omapBinder.trickyMediaPlayerHandler.seek(10);
 // Instead of dashjs.duration;
 omapBinder.trickyMediaPlayerHandler.duration;
 ```
+
+## Manifest Format Support
+
+OmapDashjsSDSustainableBinder's manifest manipulation depends on the format of the manifest dashjs plays.  Which mpd format it currently supports is shown below. 
+
+| Type | SegmentTemplate only | SegmentTimeline $Number$ | SegmentTimeline $Time$ | SegmentList | SegmentBase |
+| --- | --- | --- | --- | --- | --- | --- |
+| Video On-Demand | - | **Y** | **Y** | - | - |
+| Live | - | - | - | - | - |
+| Event | - | - | - | - | - |


### PR DESCRIPTION
This adds "Manifest Format Support" to `dash-js-sd-sustainable-binder`'s README.md