### PR TITLE
fix: Support non-browser running

### DIFF
--- a/packages/dashjs-binder/src/DashjsBinder.ts
+++ b/packages/dashjs-binder/src/DashjsBinder.ts
@@ -593,6 +593,7 @@ const CAN_ABORT_EVENT = (() => {
         }
     };
     const g = (0, eval)('this');
+    if (typeof g.addEventListener !== 'function' || typeof g.removeEventListener !== 'function') return canAbort;
     g.addEventListener('test', null, testOptions);
     Debug.log(`Is AddEventListenerOption signal available?: ${ canAbort }`);
     g.removeEventListener('test', null, testOptions);


### PR DESCRIPTION
This allows a non-browser environment to run `DashjsBinder.ts`