### PR TITLE
fix: Improve binder's destruction and ad playback error handling

### DIFF
--- a/packages/dashjs-binder/src/DashjsBinder.ts
+++ b/packages/dashjs-binder/src/DashjsBinder.ts
@@ -521,6 +521,7 @@ export default class OmapDashjsBinder implements IOmapBinder {
             }
             this._endAdPod();
             this.omapClient?.notifyAdPlaybackError(ad);
+            this.omapClient?.notifyAdPodEnded();
         }
 
         if (CAN_ABORT_EVENT) {


### PR DESCRIPTION
This improves destruction process of `DashjsSDSustainableBinder` and has `DashjsBinder` notify an OMAP client of ad pod end event on ad playback error.
