### PR TITLE
fix: DashjsSDSustainableBinder - resume content from right time

### DIFF
--- a/packages/dashjs-sd-sustainable-binder/src/DashjsSDSustainableBinder.ts
+++ b/packages/dashjs-sd-sustainable-binder/src/DashjsSDSustainableBinder.ts
@@ -15,7 +15,7 @@ import {
     shortenPeriodAt,
 } from './manifest-manipulation';
 import type { Manifest, Period } from './dashjs-types';
-import { Debug } from '../../utils/src';
+import { Debug, eraseNaN } from '../../utils/src';
 
 /**
  * Dash.js binder for OMAP clients.
@@ -88,7 +88,9 @@ export default class OmapDashjsSDSustainableBinder extends OmapDashjsSDBinder im
 
     protected override onContentResumeRequested(): void {
         Debug.log("ContentResumeRequested");
-        this._restart(this._seekingPlayheadTimeBeyondAdBreak);
+        // Try to restart the content from the restored playhead time after an ad playback is finished
+        // since the content's playhead time can be changed by the ad playback with the single decoder.
+        this._restart(this._seekingPlayheadTimeBeyondAdBreak || eraseNaN(this.lastPlayheadTime));
     }
 
     private _periodSplitInfoList: PeriodSplitInfo[] = [];

--- a/packages/utils/src/eraseNaN.ts
+++ b/packages/utils/src/eraseNaN.ts
@@ -1,0 +1,3 @@
+export default function eraseNaN(num: number): number | undefined {
+    return isNaN(num) ? void 0 : num;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,3 +1,4 @@
+export { default as eraseNaN } from "./eraseNaN";
 export { default as filterNull } from "./filterNull";
 export { default as forceArray } from "./forceArray";
 export { default as mapArrayOrElem } from "./mapArrayOrElem";

--- a/packages/utils/tests/eraseNaN.test.ts
+++ b/packages/utils/tests/eraseNaN.test.ts
@@ -1,0 +1,14 @@
+import { suite } from 'uvu';
+import * as assert from 'uvu/assert';
+import eraseNaN from '../src/eraseNaN';
+
+const test = suite('utils/eraseNaN');
+
+test("eraseNaN", () => {
+    assert.is(eraseNaN(NaN), void 0);
+    assert.is(eraseNaN(0), 0);
+    assert.is(eraseNaN(-1), -1);
+    assert.is(eraseNaN(1), 1);
+});
+
+test.run();


### PR DESCRIPTION
This fixes DashjsSDSustainableBinder to resume the content correctly from the last playhead time.
